### PR TITLE
node.js error

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -9,9 +9,9 @@ jobs:
       max-parallel: 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout
     - name: Set up Python 3.12
-      uses: actions/setup-python@v3
+      uses: actions/setup-python
       with:
         python-version: '3.12'
     - name: Add conda to system path


### PR DESCRIPTION
See prev build.
Removed the version attribute from referenced workflows.